### PR TITLE
UC4 Finish [bugfix]

### DIFF
--- a/Grocery.App/Views/ChangeColorView.xaml
+++ b/Grocery.App/Views/ChangeColorView.xaml
@@ -13,6 +13,7 @@
 
     <VerticalStackLayout>
         <Editor Text="{Binding GroceryList.Color}" x:Name="newColor"/>
-        <Button Text="wijzig kleur" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
+        <!-- UC4 Mislukte test opgelost, button text veranderd naar "Kleur bewaren" ipv "Wijzigen kleur"-->
+        <Button Text="Kleur bewaren" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" /> 
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
De veranderingen zorgen ervoor dat de bevindingen van test TC4-01 opgelost worden. Deze bevindingen waren:

"De knop om de kleur de bewaren heeft een andere tekst dan verwacht (“wijzig kleur” i.p.v. “Kleur bewaren”." TC4-01 uit test rapportage.

Text property veranderd zodat Button de juiste tekst weergeeft.